### PR TITLE
gmake: support more env vars in rules

### DIFF
--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -166,12 +166,14 @@
 		if fileconfig.hasCustomBuildRule(filecfg) then
 			local env = table.shallowcopy(filecfg.environ)
 			env.PathVars = {
-				["file.basename"] = { absolute = false, token = node.basename },
-				["file.abspath"]  = { absolute = true,  token = node.abspath },
-				["file.relpath"]  = { absolute = false, token = node.relpath },
-				["file.name"]     = { absolute = false, token = node.name },
-				["file.objname"]  = { absolute = false, token = node.objname },
-				["file.path"]     = { absolute = true,  token = node.path },
+				["file.basename"]     = { absolute = false, token = node.basename },
+				["file.abspath"]      = { absolute = true,  token = node.abspath },
+				["file.relpath"]      = { absolute = false, token = node.relpath },
+				["file.name"]         = { absolute = false, token = node.name },
+				["file.objname"]      = { absolute = false, token = node.objname },
+				["file.path"]         = { absolute = true,  token = node.path },
+				["file.directory"]    = { absolute = true,  token = path.getdirectory(node.abspath) },
+				["file.reldirectory"] = { absolute = false, token = path.getdirectory(node.relpath) },
 			}
 
 			local shadowContext = p.context.extent(filecfg, env)


### PR DESCRIPTION
This PR adds support for `file.directory` and `file.reldirectory` in custom rules for gmake backend.